### PR TITLE
feat: add RelatonEnricher for bibliography generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gemspec
 group :development do
   gem "nokogiri", "~> 1.18"
   gem "octokit", "~> 9.0"
-  gem "rubyzip", "~> 2.4"
+  gem "rubyzip", "~> 2.3"
 end

--- a/lib/metanorma/release.rb
+++ b/lib/metanorma/release.rb
@@ -94,6 +94,9 @@ module Metanorma
     # Platform factory
     autoload :PlatformFactory, "metanorma/release/platform_factory"
 
+    # Relaton enrichment
+    autoload :RelatonEnricher, "metanorma/release/relaton_enricher"
+
     # CLI & Rake
     autoload :CLI, "metanorma/release/cli"
     autoload :RakeTasks, "metanorma/release/rake_tasks"

--- a/lib/metanorma/release/relaton_enricher.rb
+++ b/lib/metanorma/release/relaton_enricher.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "relaton"
+require "json"
+require "yaml"
+require "fileutils"
+
+module Metanorma
+  module Release
+    class RelatonEnricher
+      EnrichResult = Struct.new(:item_count, :output_dir, keyword_init: true)
+
+      @flavor_registry = {}
+
+      class << self
+        def register_flavor(name, &loader)
+          @flavor_registry[name.to_s] = loader
+        end
+
+        def flavor_registry
+          @flavor_registry
+        end
+      end
+
+      register_flavor("calconnect") { require "relaton/calconnect"; Relaton::Calconnect::Item }
+      register_flavor("cc")         { require "relaton/calconnect"; Relaton::Calconnect::Item }
+      register_flavor("iso")        { require "relaton/iso"; Relaton::Iso::Item }
+      register_flavor("iec")        { require "relaton/iec"; Relaton::Iec::BibliographicItem }
+      register_flavor("ogc")        { require "relaton/ogc"; Relaton::Ogc::BibliographicItem }
+      register_flavor("ietf")       { require "relaton/ietf"; Relaton::Ietf::BibliographicItem }
+      register_flavor("bipm")       { require "relaton/bipm"; Relaton::Bipm::BibliographicItem }
+      register_flavor("itu")        { require "relaton/itu"; Relaton::Itu::BibliographicItem }
+      register_flavor("nist")       { require "relaton/nist"; Relaton::Nist::BibliographicItem }
+      register_flavor("un")         { require "relaton/un"; Relaton::Un::BibliographicItem }
+      register_flavor("bsi")        { require "relaton/bsi"; Relaton::Bsi::BibliographicItem }
+      register_flavor("ribose")     { require "relaton/ribose"; Relaton::Ribose::Item }
+
+      def initialize(flavor: nil, registry_name: "Document Registry")
+        @flavor = flavor
+        @registry_name = registry_name
+      end
+
+      def enrich(document_index, output_dir, bib_dir: "relaton")
+        return nil if document_index.empty?
+
+        flavor = resolve_flavor(document_index)
+        klass = resolve_class(flavor)
+        items = parse_rxl_files(document_index, output_dir, klass)
+        return nil if items.empty?
+
+        dest = File.join(output_dir, bib_dir)
+        write_index(items, dest)
+
+        EnrichResult.new(item_count: items.length, output_dir: dest)
+      end
+
+      private
+
+      def resolve_flavor(document_index)
+        @flavor || document_index.documents.first&.flavor
+      end
+
+      def resolve_class(flavor)
+        loader = self.class.flavor_registry[flavor.to_s]
+        return loader.call if loader
+        Relaton::Bib::Item
+      rescue LoadError
+        warn "  (relaton-#{flavor} gem not available — using base Relaton::Bib::Item)"
+        Relaton::Bib::Item
+      end
+
+      def parse_rxl_files(document_index, output_dir, klass)
+        document_index.documents.filter_map do |doc|
+          rxl = doc.files.find { |f| f.extension == "rxl" }
+          next unless rxl
+
+          path = File.join(output_dir, rxl.path)
+          next unless File.exist?(path)
+
+          klass.from_xml(File.read(path)).to_h
+        rescue StandardError => e
+          warn "  Skip #{File.basename(path)}: #{e.message}"
+          nil
+        end
+      end
+
+      def write_index(items, dest)
+        FileUtils.mkdir_p(dest)
+        index = { "root" => { "title" => @registry_name, "items" => items } }
+        File.write(File.join(dest, "index.json"), JSON.pretty_generate(index))
+        File.write(File.join(dest, "index.yaml"), YAML.dump(index))
+      end
+    end
+  end
+end

--- a/metanorma-release.gemspec
+++ b/metanorma-release.gemspec
@@ -36,6 +36,8 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"]       = "#{spec.homepage}/blob/main/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 
+  spec.add_runtime_dependency "relaton", "~> 2.0"
+
   spec.add_development_dependency "rspec", "~> 3.13"
   spec.add_development_dependency "rake", "~> 13.2"
 end

--- a/spec/aggregation/relaton_enricher_spec.rb
+++ b/spec/aggregation/relaton_enricher_spec.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "json"
+require "yaml"
+
+RSpec.describe Metanorma::Release::RelatonEnricher do
+  let(:fixtures_dir) { File.expand_path("../fixtures", __dir__) }
+  let(:sample_rxl_path) { File.join(fixtures_dir, "rxl", "sample.rxl") }
+  let(:invalid_rxl_path) { File.join(fixtures_dir, "rxl", "invalid.rxl") }
+
+  def build_index_with_rxl(rxl_paths, output_dir)
+    files = rxl_paths.map do |path|
+      name = File.basename(path)
+      dest = File.join(output_dir, name)
+      FileUtils.cp(path, dest)
+      Metanorma::Release::DocumentFile.new(name: name, path: name)
+    end
+
+    doc = Metanorma::Release::AggregatedDocument.from_h(
+      "id" => "cc-18011-2018", "title" => "Test", "edition" => "1",
+      "stage" => "published", "doctype" => "standard",
+      "channels" => ["public/standards"], "formats" => %w[rxl],
+      "flavor" => "calconnect", "contentHash" => "abc",
+      "source" => { "owner" => "CalConnect", "repo" => "cc-test",
+                     "tag" => "v1", "releaseUrl" => "", "releaseDate" => "" },
+      "files" => files.map { |f| { "name" => f.name, "path" => f.path } }
+    )
+    params = Metanorma::Release::IndexParameters.new(
+      organizations: ["CalConnect"], channels: [], topic: "test", repo_count: 1
+    )
+    Metanorma::Release::DocumentIndex.from_documents([doc], parameters: params)
+  end
+
+  def build_empty_index
+    params = Metanorma::Release::IndexParameters.new(
+      organizations: [], channels: [], topic: "test", repo_count: 0
+    )
+    Metanorma::Release::DocumentIndex.from_documents([], parameters: params)
+  end
+
+  describe "#enrich" do
+    it "produces index.json and index.yaml from RXL files" do
+      Dir.mktmpdir do |dir|
+        index = build_index_with_rxl([sample_rxl_path], dir)
+        enricher = described_class.new(registry_name: "Test Registry")
+
+        result = enricher.enrich(index, dir, bib_dir: "relaton")
+
+        expect(result).not_to be_nil
+        expect(result.item_count).to eq(1)
+
+        json_path = File.join(dir, "relaton", "index.json")
+        yaml_path = File.join(dir, "relaton", "index.yaml")
+        expect(File.exist?(json_path)).to be true
+        expect(File.exist?(yaml_path)).to be true
+
+        data = JSON.parse(File.read(json_path))
+        expect(data["root"]["title"]).to eq("Test Registry")
+        expect(data["root"]["items"].length).to eq(1)
+        expect(data["root"]["items"].first["docidentifier"].first["content"]).to eq("CC 18011:2018")
+      end
+    end
+
+    it "produces valid YAML matching JSON" do
+      Dir.mktmpdir do |dir|
+        index = build_index_with_rxl([sample_rxl_path], dir)
+        enricher = described_class.new
+        enricher.enrich(index, dir, bib_dir: "relaton")
+
+        json_data = JSON.parse(File.read(File.join(dir, "relaton", "index.json")))
+        yaml_data = YAML.unsafe_load(File.read(File.join(dir, "relaton", "index.yaml")))
+        expect(yaml_data["root"]["items"].length).to eq(json_data["root"]["items"].length)
+      end
+    end
+
+    it "returns nil for empty document index" do
+      Dir.mktmpdir do |dir|
+        enricher = described_class.new
+        result = enricher.enrich(build_empty_index, dir)
+        expect(result).to be_nil
+      end
+    end
+
+    it "returns nil when no RXL files found" do
+      Dir.mktmpdir do |dir|
+        doc = Metanorma::Release::AggregatedDocument.from_h(
+          "id" => "cc-18011", "title" => "No RXL", "edition" => "1",
+          "stage" => "published", "doctype" => "", "channels" => [],
+          "formats" => %w[html pdf], "flavor" => nil, "contentHash" => "x",
+          "source" => { "owner" => "O", "repo" => "R", "tag" => "v1",
+                         "releaseUrl" => "", "releaseDate" => "" },
+          "files" => [{ "name" => "doc.html", "path" => "doc.html" }]
+        )
+        params = Metanorma::Release::IndexParameters.new(
+          organizations: [], channels: [], topic: "test", repo_count: 1
+        )
+        index = Metanorma::Release::DocumentIndex.from_documents([doc], parameters: params)
+
+        enricher = described_class.new
+        result = enricher.enrich(index, dir)
+        expect(result).to be_nil
+      end
+    end
+
+    it "skips malformed RXL files without crashing" do
+      Dir.mktmpdir do |dir|
+        index = build_index_with_rxl([invalid_rxl_path], dir)
+        enricher = described_class.new
+
+        expect { enricher.enrich(index, dir) }.not_to raise_error
+      end
+    end
+
+    it "processes valid RXL files alongside malformed ones" do
+      Dir.mktmpdir do |dir|
+        index = build_index_with_rxl([sample_rxl_path, invalid_rxl_path], dir)
+        enricher = described_class.new
+
+        result = enricher.enrich(index, dir, bib_dir: "relaton")
+
+        expect(result).not_to be_nil
+        expect(result.item_count).to eq(1)
+      end
+    end
+
+    it "uses custom bib_dir" do
+      Dir.mktmpdir do |dir|
+        index = build_index_with_rxl([sample_rxl_path], dir)
+        enricher = described_class.new
+
+        result = enricher.enrich(index, dir, bib_dir: "bibliography")
+
+        expect(result.output_dir).to eq(File.join(dir, "bibliography"))
+        expect(File.exist?(File.join(dir, "bibliography", "index.json"))).to be true
+      end
+    end
+  end
+
+  describe "flavor handling" do
+    it "auto-detects flavor from first document" do
+      Dir.mktmpdir do |dir|
+        index = build_index_with_rxl([sample_rxl_path], dir)
+        enricher = described_class.new
+
+        result = enricher.enrich(index, dir, bib_dir: "relaton")
+        expect(result).not_to be_nil
+      end
+    end
+
+    it "uses explicit flavor parameter over auto-detection" do
+      Dir.mktmpdir do |dir|
+        index = build_index_with_rxl([sample_rxl_path], dir)
+        enricher = described_class.new(flavor: "calconnect")
+
+        result = enricher.enrich(index, dir, bib_dir: "relaton")
+        expect(result).not_to be_nil
+      end
+    end
+
+    it "falls back to base Relaton::Bib::Item for unknown flavor" do
+      Dir.mktmpdir do |dir|
+        index = build_index_with_rxl([sample_rxl_path], dir)
+        enricher = described_class.new(flavor: "unknown_flavor_xyz")
+
+        result = enricher.enrich(index, dir, bib_dir: "relaton")
+        expect(result).not_to be_nil
+        expect(result.item_count).to eq(1)
+      end
+    end
+  end
+
+  describe "flavor registry" do
+    it "has pre-registered flavors" do
+      expect(described_class.flavor_registry).to include("calconnect")
+      expect(described_class.flavor_registry).to include("cc")
+      expect(described_class.flavor_registry).to include("iso")
+    end
+
+    it "allows registering new flavors" do
+      described_class.register_flavor("test_flavor") { Relaton::Bib::Item }
+      expect(described_class.flavor_registry).to include("test_flavor")
+      described_class.flavor_registry.delete("test_flavor")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `RelatonEnricher` — a post-aggregation step that parses RXL files from aggregated output and generates Relaton bibliography data (`relaton/index.json` + `relaton/index.yaml`).

### Changes
- **`lib/metanorma/release/relaton_enricher.rb`** — New class with flavor registry for Open/Closed support
- **`spec/aggregation/relaton_enricher_spec.rb`** — 12 specs (happy path, error handling, flavor handling, registry)
- **`metanorma-release.gemspec`** — Add `relaton ~> 2.0` as runtime dependency
- **`Gemfile`** — Relax rubyzip to `~> 2.3` for relaton compatibility
- **`lib/metanorma/release.rb`** — Add autoload

### Design
- **Flavor registry**: Pre-registered flavors for calconnect, iso, iec, ogc, ietf, bipm, itu, nist, un, bsi, ribose. New flavors added via `register_flavor` without modifying existing code (Open/Closed)
- **Auto-detection**: Uses first document's `flavor` field if no explicit flavor given
- **Graceful fallback**: Falls back to `Relaton::Bib::Item` for unknown flavors or missing flavor gems
- **Error tolerance**: Malformed RXL files are skipped with warning, other files processed normally

### Test Results
337 specs, 0 failures (325 existing + 12 new)