### PR TITLE
fix: use relaton-bib instead of full relaton umbrella

### DIFF
--- a/lib/metanorma/release/relaton_enricher.rb
+++ b/lib/metanorma/release/relaton_enricher.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "relaton"
+require "relaton/bib"
 require "json"
 require "yaml"
 require "fileutils"
@@ -62,8 +62,11 @@ module Metanorma
 
       def resolve_class(flavor)
         loader = self.class.flavor_registry[flavor.to_s]
-        return loader.call if loader
-        Relaton::Bib::Item
+        if loader
+          loader.call
+        else
+          Relaton::Bib::Item
+        end
       rescue LoadError
         warn "  (relaton-#{flavor} gem not available — using base Relaton::Bib::Item)"
         Relaton::Bib::Item

--- a/metanorma-release.gemspec
+++ b/metanorma-release.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"]       = "#{spec.homepage}/blob/main/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_runtime_dependency "relaton", "~> 2.0"
+  spec.add_runtime_dependency "relaton-bib", "~> 2.1"
 
   spec.add_development_dependency "rspec", "~> 3.13"
   spec.add_development_dependency "rake", "~> 13.2"


### PR DESCRIPTION
## Problem
The `relaton` gem depends on ALL flavor gems (20+), including `relaton-w3c` which requires `w3c_api ~> 0.1.3`. Version 0.1.8 was yanked from RubyGems, causing `bundle install` to fail on CI with exit code 7.

## Fix
Replace `relaton ~> 2.0` with `relaton-bib ~> 2.1`. This provides only `Relaton::Bib::Item` (the fallback class). Flavor gems are loaded at runtime by the `RelatonEnricher` flavor registry.

## Impact
- Transitive deps: 186 → 51 gems
- Avoids yanked `w3c_api` dependency chain
- No functional change — all 337 specs pass
- Flavor-specific gems (e.g. `relaton-calconnect`) must be in the consuming app's Gemfile