### PR TITLE
rake.yml: restore workflow-level permissions to contents: write: https://github.com/metanorma/ci/issues/276

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -3,7 +3,7 @@
 name: rake
 
 permissions:
-  contents: read
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
## Summary

Restore `permissions: contents: write` at workflow level in `rake.yml`, undoing the recent tightening to `contents: read`.

## Why

The reusable workflow [`metanorma/ci/.github/workflows/generic-rake.yml`](https://github.com/metanorma/ci/blob/main/.github/workflows/generic-rake.yml) has a `tests-passed` job that legitimately requires `permissions: contents: write` (it's the consolidation step that fires `repository_dispatch` events for the downstream chain). When this caller declares `permissions: contents: read` at workflow level, GitHub's reusable-workflow permission rule treats the caller's declaration as the upper bound for any nested job's `permissions:`, so caller-`read` + nested-`write` causes static validation to reject the workflow with `startup_failure` before any job runs.

This is Consequence 1 of [metanorma/ci#276](https://github.com/metanorma/ci/issues/276). Per @ronaldtse's direction in [metanorma/ci#277 review](https://github.com/metanorma/ci/pull/277#issuecomment-4459367395) (option B in [the clarification](https://github.com/metanorma/ci/pull/277#issuecomment-4459310108)), the fix lives at the **caller's workflow level** — i.e. lift the cap here so the called workflow's `tests-passed` job can declare and use `contents: write`.

The corresponding caller-side companion change in `metanorma/ci` is [PR #277](https://github.com/metanorma/ci/pull/277) (PAT restore on the dispatch steps so they can chain into other workflows — `GITHUB_TOKEN`-fired `repository_dispatch` events don't trigger downstream workflows; only PAT-fired ones do).

## Scope

Single-line change in `.github/workflows/rake.yml`: `contents: read` → `contents: write` on the workflow-level `permissions:` block. No job-level changes.

## Test plan

- [ ] After merge: any push that routes through `tests-passed` (e.g. a tag push) should no longer fail at static validation with `Error calling workflow ... requesting 'contents: write', but is only allowed 'contents: read'`.
- [ ] The downstream `repository_dispatch` chain wired by `tests-passed` should fire as expected (this depends on metanorma/ci#277 also being merged, which restores the PAT on the dispatch steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
