### PR TITLE
refactor: code quality improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@
 /_yardoc/
 /coverage/
 /doc/
+/dist/
 /pkg/
 /spec/reports/
 /tmp/
 *.gem
-*.lock
 Gemfile.lock
+.rspec_status
+.rubocop*.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.0 (Unreleased)
+
+- Fix ReleaseTag eql?/hash to include pre_release flag
+- Fix private class methods in ChannelRegistry and ChannelConfig (use private_class_method)
+- Eliminate double YAML parsing in ChannelConfig.from_yaml
+- Unify release/asset data types (ReleaseData/AssetData) across GitHub and Local fetchers
+- Add ZipPackager unit spec
+- Expand DocumentMetadata spec coverage
+- Expand AggregationPipeline spec coverage (error handling, filtering, drafts)
+
 ## 0.1.0 (Unreleased)
 
 - Initial release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+```
+bundle install
+bundle exec rspec                    # run all tests
+bundle exec rspec spec/domain/       # run tests for a directory
+bundle exec rspec spec/domain/channel_spec.rb  # run a single spec file
+bundle exec rspec spec/domain/channel_spec.rb:42  # run a single example by line
+bundle exec rake                     # runs rspec (default task)
+```
+
+The spec directory mirrors the source: `lib/metanorma/release/channel.rb` → `spec/domain/channel_spec.rb`, `lib/metanorma/release/release_pipeline.rb` → `spec/release/release_pipeline_spec.rb`, platform adapters → `spec/platform/`.
+
+## Architecture
+
+This is `metanorma-release`, a Ruby gem (>= 3.2) for managing the release lifecycle of Metanorma documents. It has two main pipelines:
+
+- **ReleasePipeline** (producer): discover compiled docs → extract metadata from RXL → detect changes → package as zip → publish to platform
+- **AggregationPipeline** (consumer): discover repos → fetch releases → filter by channel/stage → extract assets → generate `index.json` + file tree
+
+### Dependency flow (unidirectional, no cycles)
+
+```
+domain/  →  release/  →  platform/
+         →  aggregation/ →  platform/
+                          →  cli/
+```
+
+- `domain/` (value objects): zero knowledge of pipelines, platforms, or CLI
+- Pipelines depend on domain + interfaces, not platform implementations
+- Platform adapters (`platform/github/`, `platform/local/`, `platform/null/`) depend on interfaces + domain
+- CLI (`cli.rb`) wires pipelines + platform factory together
+
+### Key patterns
+
+- **Value Objects**: Immutable, frozen, value-based equality (`eql?`/`hash`). Factory methods via `self.from_*`.
+- **Strategy Pattern**: Pluggable algorithms resolved via registry (naming strategies, file routing modes, platforms).
+- **Pipeline with DI**: Pipelines receive all deps through constructor Structs (`Dependencies`, `Config`). No global state.
+- **Null Object**: Disabled features inject null implementations (`NullDeltaState`, `NullPublisher`, `NullCacheStore`).
+- **Interface modules** (`interfaces.rb`, `aggregation_interfaces.rb`): Ruby modules with `NotImplementedError` stubs. Concrete classes `include` them. Never use `respond_to?` to check.
+
+### Core domain types
+
+`DocumentId`, `DocumentVersion`, `DocumentStage`, `DocumentType`, `Channel`, `ChannelAudience`, `ContentHash`, `ReleaseTag`, `RepoRef`, `ChannelConfig`, `ChannelRegistry`.
+
+### Extending
+
+| To add... | Do this |
+|-----------|---------|
+| New platform | Create `platform/<name>/` with `Publisher`, `Discoverer`, `Fetcher`, `ManifestReader`; register in `PlatformFactory` |
+| New naming strategy | Create class including `NamingStrategy`; register via `NamingRegistry#register` |
+| New file routing mode | Create class with `#compute_path(file_name, metadata)`; register in `FileRoutingFactory` |
+| New filter | Create class including `Filter`; pass to pipeline's `filters` array |
+
+## Hard Rules
+
+- **Never use `send`, `__send__`, `respond_to?`, or `method_missing`** — use Strategy pattern and interface modules instead
+- **No type conditionals** (`if x.is_a?(...)`, `case platform when :github`) — use polymorphism
+- **All value objects are frozen** — no mutation after construction; implement `eql?` and `hash`
+- **`# frozen_string_literal: true`** at the top of every Ruby file
+- **No runtime dependencies** in the gemspec beyond `relaton-bib` — platform-specific gems (`octokit`, etc.) are loaded lazily with `rescue LoadError`
+- **Errors collected, not raised** in pipelines — callers inspect `result.failed`
+- **No comments** unless the WHY is non-obvious; no multi-line docstrings
+
+## Testing Conventions
+
+- Pipeline specs use mock adapters (Struct-based) implementing interface modules — no real I/O or HTTP
+- Integration specs use local adapters with committed fixtures in `spec/fixtures/`
+- Shared examples for interface conformance (e.g., `"a naming strategy"`)
+- Test factories in `spec/support/factories.rb` (included via RSpec config)
+- Test both happy paths and edge cases (invalid input, fallbacks, normalization)

--- a/README.adoc
+++ b/README.adoc
@@ -383,7 +383,7 @@ domain/  ->  release/  ->  platform/
 
 === Patterns
 
-Value Objects:: Immutable, frozen, value-based equality via `eql?`/`hash`.
+Value Objects:: Immutable, frozen, value-based equality via `eql?`/`hash`. All fields included in equality comparison.
 
 Strategy Pattern:: Pluggable algorithms resolved via registry. Adding a new document type or platform requires zero changes to existing code.
 
@@ -392,6 +392,8 @@ Pipeline with DI:: Pipelines receive all dependencies through constructors. No g
 Null Object:: Disabled features inject null implementations (`NullDeltaState`, `NullPublisher`, `NullCacheStore`) instead of adding conditional checks.
 
 Result Types:: Pipelines return frozen Structs. Errors are collected, not raised. The caller decides whether to abort.
+
+Shared Data Types:: `ReleaseData` and `AssetData` in `aggregation_interfaces.rb` are the canonical Structs for release/asset data used across all platform adapters (GitHub, Local). Platform-specific aliases are not needed.
 
 === Extending
 

--- a/exe/metanorma-release
+++ b/exe/metanorma-release
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "metanorma/release/cli"
+
+Metanorma::Release::Cli.start(ARGV)

--- a/lib/metanorma/release.rb
+++ b/lib/metanorma/release.rb
@@ -2,107 +2,114 @@
 
 module Metanorma
   module Release
-    VERSION = "0.2.0"
+    VERSION = '0.2.0'
 
     # Domain value objects
-    autoload :ChannelAudience, "metanorma/release/channel_audience"
-    autoload :Channel,         "metanorma/release/channel"
-    autoload :ChannelRegistry, "metanorma/release/channel_registry"
-    autoload :ChannelConfig,   "metanorma/release/channel_config"
-    autoload :ConfigLocator,   "metanorma/release/config_locator"
-    autoload :ContentHash,     "metanorma/release/content_hash"
-    autoload :DocumentId,      "metanorma/release/document_id"
-    autoload :DocumentStage,   "metanorma/release/document_stage"
-    autoload :DocumentType,    "metanorma/release/document_type"
-    autoload :DocumentVersion, "metanorma/release/document_version"
-    autoload :ReleaseTag,      "metanorma/release/release_tag"
-    autoload :RepoRef,         "metanorma/release/repo_ref"
+    autoload :ChannelAudience, 'metanorma/release/channel_audience'
+    autoload :Channel,         'metanorma/release/channel'
+    autoload :ChannelRegistry, 'metanorma/release/channel_registry'
+    autoload :ChannelConfig,   'metanorma/release/channel_config'
+    autoload :ConfigLocator,   'metanorma/release/config_locator'
+    autoload :ContentHash,     'metanorma/release/content_hash'
+    autoload :DocumentId,      'metanorma/release/document_id'
+    autoload :DocumentStage,   'metanorma/release/document_stage'
+    autoload :DocumentType,    'metanorma/release/document_type'
+    autoload :DocumentVersion, 'metanorma/release/document_version'
+    autoload :ReleaseTag,      'metanorma/release/release_tag'
+    autoload :RepoRef,         'metanorma/release/repo_ref'
 
     # Domain strategies
-    autoload :NamingStrategy,      "metanorma/release/naming_strategy"
-    autoload :EditionNaming,       "metanorma/release/naming_strategy"
-    autoload :VersionNaming,       "metanorma/release/naming_strategy"
-    autoload :InternetDraftNaming, "metanorma/release/naming_strategy"
-    autoload :RfcNaming,           "metanorma/release/naming_strategy"
-    autoload :DraftSuffixNaming,   "metanorma/release/naming_strategy"
-    autoload :NamingRegistry,      "metanorma/release/naming_strategy"
+    autoload :NamingStrategy,      'metanorma/release/naming_strategy'
+    autoload :EditionNaming,       'metanorma/release/naming_strategy'
+    autoload :VersionNaming,       'metanorma/release/naming_strategy'
+    autoload :InternetDraftNaming, 'metanorma/release/naming_strategy'
+    autoload :RfcNaming,           'metanorma/release/naming_strategy'
+    autoload :DraftSuffixNaming,   'metanorma/release/naming_strategy'
+    autoload :NamingRegistry,      'metanorma/release/naming_strategy'
 
     # Manifest & policy
-    autoload :ChannelManifest,       "metanorma/release/channel_manifest"
-    autoload :DocumentReleasePolicy, "metanorma/release/channel_manifest"
-    autoload :ManifestEntry,         "metanorma/release/channel_manifest"
+    autoload :ChannelManifest,       'metanorma/release/channel_manifest'
+    autoload :DocumentReleasePolicy, 'metanorma/release/channel_manifest'
+    autoload :ManifestEntry,         'metanorma/release/channel_manifest'
 
     # Metadata
-    autoload :DocumentMetadata, "metanorma/release/document_metadata"
-    autoload :ReleaseMetadata,  "metanorma/release/release_metadata"
-    autoload :RxlExtractor,     "metanorma/release/rxl_extractor"
+    autoload :DocumentMetadata, 'metanorma/release/document_metadata'
+    autoload :ReleaseMetadata,  'metanorma/release/release_metadata'
+    autoload :RxlExtractor,     'metanorma/release/rxl_extractor'
 
     # Interfaces
-    autoload :Extractor,        "metanorma/release/interfaces"
-    autoload :Filter,           "metanorma/release/interfaces"
-    autoload :ChangeDetector,   "metanorma/release/interfaces"
-    autoload :Packager,         "metanorma/release/interfaces"
-    autoload :Publisher,        "metanorma/release/interfaces"
+    autoload :Extractor,        'metanorma/release/interfaces'
+    autoload :Filter,           'metanorma/release/interfaces'
+    autoload :ChangeDetector,   'metanorma/release/interfaces'
+    autoload :Packager,         'metanorma/release/interfaces'
+    autoload :Publisher,        'metanorma/release/interfaces'
 
     # Pipeline components
-    autoload :ChangeResult,              "metanorma/release/interfaces"
-    autoload :Artifact,                  "metanorma/release/interfaces"
-    autoload :PublishResult,             "metanorma/release/interfaces"
-    autoload :ReleasedArtifact,          "metanorma/release/interfaces"
-    autoload :ReleaseResult,             "metanorma/release/interfaces"
-    autoload :ContentHashChangeDetector, "metanorma/release/change_detector"
-    autoload :ZipPackager,               "metanorma/release/zip_packager"
-    autoload :ReleasePipeline,           "metanorma/release/release_pipeline"
+    autoload :ChangeResult,              'metanorma/release/interfaces'
+    autoload :Artifact,                  'metanorma/release/interfaces'
+    autoload :PublishResult,             'metanorma/release/interfaces'
+    autoload :ReleasedArtifact,          'metanorma/release/interfaces'
+    autoload :ReleaseResult,             'metanorma/release/interfaces'
+    autoload :ContentHashChangeDetector, 'metanorma/release/change_detector'
+    autoload :ZipPackager,               'metanorma/release/zip_packager'
+    autoload :ReleasePipeline,           'metanorma/release/release_pipeline'
 
     # Cache
-    autoload :CacheStore,      "metanorma/release/cache_store"
-    autoload :FileCacheStore,  "metanorma/release/cache_store"
-    autoload :NullCacheStore,  "metanorma/release/cache_store"
+    autoload :CacheStore,      'metanorma/release/cache_store'
+    autoload :FileCacheStore,  'metanorma/release/cache_store'
+    autoload :NullCacheStore,  'metanorma/release/cache_store'
 
     # Aggregation filters
-    autoload :ChannelFilter,   "metanorma/release/channel_filter"
-    autoload :ConfigFetcher,   "metanorma/release/config_fetcher"
-    autoload :StageFilter,   "metanorma/release/stage_filter"
-    autoload :DeltaState,    "metanorma/release/delta_state"
-    autoload :NullDeltaState, "metanorma/release/delta_state"
+    autoload :ChannelFilter,   'metanorma/release/channel_filter'
+    autoload :ConfigFetcher,   'metanorma/release/config_fetcher'
+    autoload :StageFilter,   'metanorma/release/stage_filter'
+    autoload :DeltaState,    'metanorma/release/delta_state'
+    autoload :NullDeltaState, 'metanorma/release/delta_state'
 
     # Document index
-    autoload :DocumentFile,       "metanorma/release/document_index"
-    autoload :DocumentSource,     "metanorma/release/document_index"
-    autoload :IndexParameters,    "metanorma/release/document_index"
-    autoload :IndexSummary,       "metanorma/release/document_index"
-    autoload :AggregatedDocument, "metanorma/release/document_index"
-    autoload :DocumentIndex,      "metanorma/release/document_index"
+    autoload :DocumentFile,       'metanorma/release/document_index'
+    autoload :DocumentSource,     'metanorma/release/document_index'
+    autoload :IndexParameters,    'metanorma/release/document_index'
+    autoload :IndexSummary,       'metanorma/release/document_index'
+    autoload :AggregatedDocument, 'metanorma/release/document_index'
+    autoload :DocumentIndex,      'metanorma/release/document_index'
 
     # Asset processing
-    autoload :FileRouting,       "metanorma/release/file_routing"
-    autoload :ByDocument,        "metanorma/release/file_routing"
-    autoload :Flat,              "metanorma/release/file_routing"
-    autoload :ByFormat,          "metanorma/release/file_routing"
-    autoload :FileRoutingFactory, "metanorma/release/file_routing"
-    autoload :AssetProcessor,    "metanorma/release/asset_processor"
+    autoload :FileRouting,       'metanorma/release/file_routing'
+    autoload :ByDocument,        'metanorma/release/file_routing'
+    autoload :Flat,              'metanorma/release/file_routing'
+    autoload :ByFormat,          'metanorma/release/file_routing'
+    autoload :FileRoutingFactory, 'metanorma/release/file_routing'
+    autoload :AssetProcessor,    'metanorma/release/asset_processor'
 
     # Aggregation
-    autoload :RepoDiscoverer,    "metanorma/release/aggregation_interfaces"
-    autoload :ReleaseFetcher,    "metanorma/release/aggregation_interfaces"
-    autoload :ManifestReader,    "metanorma/release/aggregation_interfaces"
-    autoload :IndexGenerator,    "metanorma/release/aggregation_interfaces"
-    autoload :FetchResult,       "metanorma/release/aggregation_interfaces"
-    autoload :RepoReport,        "metanorma/release/aggregation_interfaces"
-    autoload :RepoError,         "metanorma/release/aggregation_interfaces"
-    autoload :AggregationPipeline, "metanorma/release/aggregation_pipeline"
+    autoload :RepoDiscoverer,    'metanorma/release/aggregation_interfaces'
+    autoload :ReleaseFetcher,    'metanorma/release/aggregation_interfaces'
+    autoload :ManifestReader,    'metanorma/release/aggregation_interfaces'
+    autoload :IndexGenerator,    'metanorma/release/aggregation_interfaces'
+    autoload :FetchResult,       'metanorma/release/aggregation_interfaces'
+    autoload :RepoReport,        'metanorma/release/aggregation_interfaces'
+    autoload :RepoError,         'metanorma/release/aggregation_interfaces'
+    autoload :ReleaseData,       'metanorma/release/aggregation_interfaces'
+    autoload :AssetData,         'metanorma/release/aggregation_interfaces'
+    autoload :AggregationPipeline, 'metanorma/release/aggregation_pipeline'
 
     # Platform namespace
-    autoload :Platform, "metanorma/release/platform"
+    autoload :Platform, 'metanorma/release/platform'
 
     # Platform factory
-    autoload :PlatformFactory, "metanorma/release/platform_factory"
+    autoload :PlatformFactory, 'metanorma/release/platform_factory'
 
     # Relaton enrichment
-    autoload :RelatonEnricher, "metanorma/release/relaton_enricher"
+    autoload :RelatonEnricher, 'metanorma/release/relaton_enricher'
 
     # CLI & Rake
-    autoload :CLI, "metanorma/release/cli"
-    autoload :RakeTasks, "metanorma/release/rake_tasks"
+    autoload :CLI, 'metanorma/release/cli'
+    autoload :RakeTasks, 'metanorma/release/rake_tasks'
+    autoload :AggregateConfig, 'metanorma/release/aggregate_config'
+    autoload :ConfigResolver, 'metanorma/release/config_resolver'
+    autoload :PackageCommand, 'metanorma/release/commands/package'
+    autoload :PublishCommand, 'metanorma/release/commands/publish'
+    autoload :AggregateCommand, 'metanorma/release/commands/aggregate'
   end
 end

--- a/lib/metanorma/release/aggregate_config.rb
+++ b/lib/metanorma/release/aggregate_config.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Metanorma
+  module Release
+    class AggregateConfig
+      attr_reader :source, :organizations, :topic, :repos, :repo_pattern,
+                  :channels, :stages, :output_dir, :file_routing,
+                  :local_path
+
+      def self.load(path = nil)
+        path ||= find_config
+        return default unless path && File.exist?(path)
+
+        new(YAML.safe_load(File.read(path)))
+      end
+
+      def self.find_config
+        %w[metanorma.aggregate.yml metanorma.yml].find { |f| File.exist?(f) }
+      end
+
+      def self.default
+        new({})
+      end
+
+      def initialize(data)
+        @source = data['source'] || 'github'
+        @output_dir = data['output_dir'] || '_site/cc'
+        @file_routing = data['file_routing'] || 'by-document'
+        @channels = data['channels'] || []
+        @stages = data['stages'] || []
+
+        src = data[@source] || {}
+        @organizations = src['organizations'] || []
+        @topic = src['topic'] || 'metanorma-release'
+        @repos = src['repos']
+        @repo_pattern = src['repo_pattern']
+        @local_path = src['path']
+      end
+    end
+  end
+end

--- a/lib/metanorma/release/aggregation_interfaces.rb
+++ b/lib/metanorma/release/aggregation_interfaces.rb
@@ -29,5 +29,11 @@ module Metanorma
     FetchResult = Struct.new(:releases, :etag, :unchanged?, keyword_init: true)
     RepoReport  = Struct.new(:releases, :included, :skipped, :reason, :errors, keyword_init: true)
     RepoError   = Struct.new(:tag, :message, keyword_init: true)
+
+    ReleaseData = Struct.new(:tag_name, :body, :prerelease, :draft,
+                             :html_url, :published_at, :created_at,
+                             :assets, keyword_init: true)
+    AssetData = Struct.new(:name, :browser_download_url, :size, :data,
+                           keyword_init: true)
   end
 end

--- a/lib/metanorma/release/channel_config.rb
+++ b/lib/metanorma/release/channel_config.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require "yaml"
+require 'yaml'
 
 module Metanorma
   module Release
     class ChannelConfig
       def self.from_yaml(yaml_string)
         data = YAML.safe_load(yaml_string, permitted_classes: [Symbol])
-        raise ArgumentError, "Invalid channel config YAML" unless data.is_a?(Hash)
+        raise ArgumentError, 'Invalid channel config YAML' unless data.is_a?(Hash)
 
-        registry = ChannelRegistry.from_yaml(yaml_string)
-        defaults = data["defaults"] || {}
-        default_visibility = defaults["visibility"] || "public"
-        default_channels = parse_channels(defaults["channels"])
+        registry = ChannelRegistry.from_data(data)
+        defaults = data['defaults'] || {}
+        default_visibility = defaults['visibility'] || 'public'
+        default_channels = parse_channels(defaults['channels'])
 
         new(registry: registry, default_visibility: default_visibility,
             default_channels: default_channels)
@@ -20,7 +20,7 @@ module Metanorma
 
       def self.from_file(path)
         if File.directory?(path)
-          channels_yml = File.join(path, "channels.yml")
+          channels_yml = File.join(path, 'channels.yml')
           raise ArgumentError, "Channel config file not found: #{path}" unless File.exist?(channels_yml)
 
           return from_file(channels_yml)
@@ -33,7 +33,7 @@ module Metanorma
 
       def self.empty
         new(registry: ChannelRegistry.all_allowed,
-            default_visibility: "public", default_channels: [])
+            default_visibility: 'public', default_channels: [])
       end
 
       def initialize(registry:, default_visibility:, default_channels:)
@@ -45,13 +45,13 @@ module Metanorma
 
       attr_reader :registry, :default_visibility, :default_channels
 
-      private
-
       def self.parse_channels(list)
         return [] unless list
 
         list.map { |c| Channel.parse(c.to_s) }
       end
+
+      private_class_method :parse_channels
     end
   end
 end

--- a/lib/metanorma/release/channel_registry.rb
+++ b/lib/metanorma/release/channel_registry.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-require "yaml"
+require 'yaml'
 
 module Metanorma
   module Release
     class ChannelRegistry
       def self.from_yaml(yaml_string)
         data = YAML.safe_load(yaml_string, permitted_classes: [Symbol])
-        raise ArgumentError, "Invalid channel registry YAML" unless data.is_a?(Hash)
+        raise ArgumentError, 'Invalid channel registry YAML' unless data.is_a?(Hash)
 
-        channels = parse_channel_list(data["channels"])
+        from_data(data)
+      end
+
+      def self.from_data(data)
+        channels = parse_channel_list(data['channels'])
         new(channels: channels)
       end
 
@@ -40,26 +44,24 @@ module Metanorma
         valid?(channel)
       end
 
-      def channels
-        @channels
-      end
+      attr_reader :channels
 
       def empty?
         @channels.empty?
       end
-
-      private
 
       def self.parse_channel_list(list)
         return [] unless list
 
         list.filter_map do |entry|
           case entry
-          when Hash   then Channel.parse(entry["name"].to_s)
+          when Hash   then Channel.parse(entry['name'].to_s)
           when String then Channel.parse(entry)
           end
         end
       end
+
+      private_class_method :parse_channel_list
     end
   end
 end

--- a/lib/metanorma/release/commands/aggregate.rb
+++ b/lib/metanorma/release/commands/aggregate.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Release
+    class AggregateCommand
+      Config = Struct.new(
+        :source, :organizations, :topic, :repos, :repo_pattern, :local_path,
+        :channels, :stages, :output_dir, :file_routing, :cache_dir,
+        :include_drafts, :concurrency, :min_documents, :token, :zip,
+        keyword_init: true
+      )
+
+      def initialize(config)
+        @config = config
+      end
+
+      def call
+        result = run_aggregation
+        enrich(result) if result.documents.any?
+        zip_output if @config.zip
+        result
+      end
+
+      private
+
+      def run_aggregation
+        adapters = PlatformFactory.build_aggregation_adapters(
+          source: @config.local_path ? "local:#{@config.local_path}" : @config.source,
+          organizations: @config.organizations,
+          topic: @config.topic,
+          repos: @config.repos,
+          token: @config.token
+        )
+
+        channel_filter = ChannelFilter.new(
+          channels: (@config.channels || []).map { |s| Channel.parse(s) }
+        )
+        stage_filter = StageFilter.new(stages: @config.stages || [])
+        routing = FileRoutingFactory.from_name(@config.file_routing)
+        asset_processor = AssetProcessor.new(
+          output_dir: @config.output_dir,
+          routing: routing,
+          canonicalize: true
+        )
+        delta_state = if @config.cache_dir
+                        DeltaState.new(
+                          cache_store: FileCacheStore.new(@config.cache_dir),
+                          output_dir: @config.output_dir
+                        )
+                      else
+                        NullDeltaState.new
+                      end
+
+        deps = AggregationPipeline::Dependencies.new(
+          discoverer: adapters[:discoverer],
+          fetcher: adapters[:fetcher],
+          manifest_reader: adapters[:manifest_reader],
+          channel_filter: channel_filter,
+          stage_filter: stage_filter,
+          asset_processor: asset_processor,
+          delta_state: delta_state
+        )
+
+        config = AggregationPipeline::Config.new(
+          organizations: @config.organizations,
+          channels: @config.channels,
+          topic: @config.topic,
+          concurrency: @config.concurrency,
+          include_drafts: @config.include_drafts,
+          fail_on_error: false
+        )
+
+        AggregationPipeline.new(deps).run(config, @config.output_dir)
+      end
+
+      def enrich(result)
+        index = DocumentIndex.from_documents(
+          result.documents,
+          parameters: IndexParameters.new(
+            organizations: @config.organizations,
+            channels: @config.channels || [],
+            topic: @config.topic,
+            repo_count: result.repo_count
+          )
+        )
+        enricher = RelatonEnricher.new
+        enrich_result = enricher.enrich(index, @config.output_dir)
+        return unless enrich_result
+
+        stamp_primary_identifiers!(enrich_result.documents)
+      rescue LoadError
+        warn '  (relaton gem not available — bibliography skipped)'
+      end
+
+      def stamp_primary_identifiers!(documents)
+        documents.each do |doc|
+          bib = doc['bibliographic']
+          next unless bib
+
+          ids = bib['docidentifier']
+          next unless ids&.any?
+
+          primary = ids.find { |di| di['primary'] == true } || ids.first
+          doc['primary_identifier'] = primary['content']
+        end
+      end
+
+      def zip_output
+        require 'rubygems/package'
+        require 'zlib'
+
+        dir = @config.output_dir
+        zip_path = "#{dir}.zip"
+
+        Dir.chdir(File.dirname(dir)) do
+          IO.write(zip_path, '')
+          Zlib::GzipWriter.open(zip_path) do |gz|
+            Gem::Package::TarWriter.new(gz) do |tar|
+              Dir.glob("#{File.basename(dir)}/**/*").each do |file|
+                next if File.directory?(file)
+
+                tar.add_file(file, 0o644) do |io|
+                  io.write(File.read(file))
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/release/commands/package.rb
+++ b/lib/metanorma/release/commands/package.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Release
+    class PackageCommand
+      Config = Struct.new(
+        :output_dir, :dest, :manifest, :config_source, :zip,
+        keyword_init: true
+      )
+
+      include ConfigResolver
+
+      def initialize(config)
+        @config = config
+      end
+
+      def call
+        manifest = load_manifest(@config.manifest)
+        channel_config = resolve_channel_config(@config.config_source, manifest)
+
+        deps = ReleasePipeline::Dependencies.new(
+          extractor: RxlExtractor.new,
+          filters: [],
+          change_detector: ContentHashChangeDetector.new(previous_releases: {}),
+          packager: ZipPackager.new,
+          publisher: PlatformFactory.build_publisher('null', {}),
+          naming_registry: NamingRegistry.default_registry,
+          manifest: manifest,
+          channel_override: nil,
+          channel_config: channel_config
+        )
+
+        pipeline_config = ReleasePipeline::Config.new(
+          output_dir: @config.output_dir,
+          manifest_path: @config.manifest,
+          force: false,
+          force_replace_patterns: nil,
+          concurrency: 4,
+          default_visibility: 'public'
+        )
+
+        ReleasePipeline.new(deps).run(pipeline_config)
+      end
+    end
+  end
+end

--- a/lib/metanorma/release/commands/publish.rb
+++ b/lib/metanorma/release/commands/publish.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Release
+    class PublishCommand
+      Config = Struct.new(
+        :output_dir, :platform, :manifest, :force,
+        :force_replace, :channels, :concurrency, :token, :config_source,
+        keyword_init: true
+      )
+
+      include ConfigResolver
+
+      def initialize(config)
+        @config = config
+      end
+
+      def call
+        manifest = load_manifest(@config.manifest)
+        channel_config = resolve_channel_config(@config.config_source, manifest)
+
+        options = { token: @config.token }
+        publisher = PlatformFactory.build_publisher(@config.platform, options)
+        channel_override = parse_channels(@config.channels) if @config.channels
+
+        deps = ReleasePipeline::Dependencies.new(
+          extractor: RxlExtractor.new,
+          filters: [],
+          change_detector: ContentHashChangeDetector.new(previous_releases: {}),
+          packager: ZipPackager.new,
+          publisher: publisher,
+          naming_registry: NamingRegistry.default_registry,
+          manifest: manifest,
+          channel_override: channel_override,
+          channel_config: channel_config
+        )
+
+        pipeline_config = ReleasePipeline::Config.new(
+          output_dir: @config.output_dir,
+          manifest_path: @config.manifest,
+          force: @config.force,
+          force_replace_patterns: @config.force_replace && @config.force_replace.empty? ? nil : @config.force_replace,
+          concurrency: @config.concurrency,
+          default_visibility: 'public'
+        )
+
+        ReleasePipeline.new(deps).run(pipeline_config)
+      end
+
+      private
+
+      def parse_channels(strings)
+        (strings || []).map { |s| Channel.parse(s) }
+      end
+    end
+  end
+end

--- a/lib/metanorma/release/config_resolver.rb
+++ b/lib/metanorma/release/config_resolver.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Release
+    module ConfigResolver
+      def resolve_channel_config(cli_source, manifest)
+        return fetch_config(cli_source) if cli_source
+        return fetch_config(manifest.config_source) if manifest&.config_source
+
+        found = ConfigLocator.find
+        return found if found
+
+        ChannelConfig.empty
+      end
+
+      def load_manifest(path)
+        return nil unless path && File.exist?(path)
+
+        ChannelManifest.from_file(path)
+      end
+
+      private
+
+      def fetch_config(source)
+        if source.start_with?('local:')
+          Platform::Local::ConfigFetcher.new.fetch(source)
+        elsif source.include?('/')
+          Platform::Local::ConfigFetcher.new.fetch("local:#{source}")
+        else
+          require 'octokit'
+          client = PlatformFactory.build_github_client(nil)
+          Platform::GitHub::ConfigFetcher.new(client: client).fetch(source)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/release/platform/github/release_fetcher.rb
+++ b/lib/metanorma/release/platform/github/release_fetcher.rb
@@ -4,12 +4,6 @@ module Metanorma
   module Release
     module Platform
       module GitHub
-        GitHubRelease = Struct.new(:tag_name, :body, :prerelease, :draft,
-                                   :html_url, :published_at, :created_at,
-                                   :assets, keyword_init: true)
-        GitHubAsset = Struct.new(:name, :browser_download_url, :size, :data,
-                                 keyword_init: true)
-
         class ReleaseFetcher
           include Metanorma::Release::ReleaseFetcher
 
@@ -27,14 +21,14 @@ module Metanorma
 
           def parse_release(r)
             assets = (r[:assets] || []).map do |a|
-              GitHubAsset.new(
+              AssetData.new(
                 name: a[:name],
                 browser_download_url: a[:browser_download_url],
                 size: a[:size],
                 data: nil
               )
             end
-            GitHubRelease.new(
+            ReleaseData.new(
               tag_name: r[:tag_name],
               body: r[:body],
               prerelease: r[:prerelease],

--- a/lib/metanorma/release/platform/local/fetcher.rb
+++ b/lib/metanorma/release/platform/local/fetcher.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-require "json"
+require 'json'
 
 module Metanorma
   module Release
     module Platform
       module Local
-        LocalRelease = Struct.new(:tag_name, :body, :prerelease, :draft,
-                                  :html_url, :published_at, :created_at,
-                                  :assets, keyword_init: true)
-        LocalAsset = Struct.new(:name, :browser_download_url, :size, :data,
-                                keyword_init: true)
-
         class Fetcher
           include Metanorma::Release::ReleaseFetcher
+
+          DRAFT_STAGES = %w[working-draft committee-draft draft-standard final-draft].freeze
 
           def initialize(base_path:)
             @base_path = base_path
@@ -23,7 +19,7 @@ module Metanorma
             dir = File.join(@base_path, repo.repo)
             return FetchResult.new(releases: [], etag: nil, unchanged?: false) unless Dir.exist?(dir)
 
-            releases = Dir.glob(File.join(dir, "*.meta.json")).filter_map do |meta_path|
+            releases = Dir.glob(File.join(dir, '*.meta.json')).filter_map do |meta_path|
               build_release(dir, meta_path)
             end
 
@@ -34,7 +30,7 @@ module Metanorma
 
           def build_release(dir, meta_path)
             data = JSON.parse(File.read(meta_path))
-            base = File.basename(meta_path, ".meta.json")
+            base = File.basename(meta_path, '.meta.json')
             zip_path = File.join(dir, "#{base}.zip")
 
             unless File.exist?(zip_path)
@@ -43,21 +39,22 @@ module Metanorma
             end
 
             metadata = ReleaseMetadata.new(data)
-            asset = LocalAsset.new(
+            asset = AssetData.new(
               name: "#{base}.zip",
               browser_download_url: "file://#{File.expand_path(zip_path)}",
               size: File.size(zip_path),
               data: File.binread(zip_path)
             )
 
-            LocalRelease.new(
+            mtime = File.mtime(zip_path).iso8601
+            ReleaseData.new(
               tag_name: "#{data['id']}/#{data.fetch('edition', '1')}",
               body: metadata.to_release_body,
               prerelease: prerelease?(data),
               draft: false,
               html_url: "file://#{File.expand_path(dir)}",
-              published_at: File.mtime(zip_path).iso8601,
-              created_at: File.mtime(zip_path).iso8601,
+              published_at: mtime,
+              created_at: mtime,
               assets: [asset]
             )
           rescue JSON::ParserError
@@ -66,8 +63,7 @@ module Metanorma
           end
 
           def prerelease?(data)
-            stage = data["stage"].to_s
-            %w[working-draft committee-draft draft-standard final-draft].include?(stage)
+            DRAFT_STAGES.include?(data['stage'].to_s)
           end
         end
       end

--- a/lib/metanorma/release/release_tag.rb
+++ b/lib/metanorma/release/release_tag.rb
@@ -11,13 +11,13 @@ module Metanorma
       end
 
       def self.create(tag, pre_release:)
-        raise ArgumentError, "Tag must contain a slash separator" unless tag.include?("/")
+        raise ArgumentError, 'Tag must contain a slash separator' unless tag.include?('/')
 
         new(tag: tag, pre_release: pre_release)
       end
 
       def self.parse(tag)
-        raise ArgumentError, "Tag must contain a slash separator" unless tag.include?("/")
+        raise ArgumentError, 'Tag must contain a slash separator' unless tag.include?('/')
 
         pre = PRE_RELEASE_SUFFIXES.any? { |s| tag.include?(s) }
         new(tag: tag, pre_release: pre)
@@ -38,11 +38,11 @@ module Metanorma
       end
 
       def eql?(other)
-        other.is_a?(self.class) && @tag == other.to_s
+        other.is_a?(self.class) && @tag == other.to_s && @pre_release == other.pre_release?
       end
 
       def hash
-        @tag.hash
+        [@tag, @pre_release].hash
       end
     end
   end

--- a/spec/aggregate_config_spec.rb
+++ b/spec/aggregate_config_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
+RSpec.describe Metanorma::Release::AggregateConfig do
+  describe '.load' do
+    it 'loads config from explicit path' do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, 'test.yml')
+        File.write(config_path, <<~YAML)
+          source: github
+          output_dir: _site/docs
+          github:
+            organizations:
+              - MyOrg
+            topic: my-topic
+            repo_pattern: "doc-*"
+        YAML
+
+        config = described_class.load(config_path)
+        expect(config.source).to eq('github')
+        expect(config.organizations).to eq(['MyOrg'])
+        expect(config.topic).to eq('my-topic')
+        expect(config.repo_pattern).to eq('doc-*')
+        expect(config.output_dir).to eq('_site/docs')
+      end
+    end
+
+    it 'returns defaults when no config file found' do
+      config = described_class.load('/nonexistent/path.yml')
+      expect(config.source).to eq('github')
+      expect(config.organizations).to eq([])
+      expect(config.output_dir).to eq('_site/cc')
+    end
+
+    it 'parses local source with path' do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, 'local.yml')
+        File.write(config_path, <<~YAML)
+          source: local
+          local:
+            path: /data/docs
+        YAML
+
+        config = described_class.load(config_path)
+        expect(config.source).to eq('local')
+        expect(config.local_path).to eq('/data/docs')
+      end
+    end
+
+    it 'parses content filters' do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, 'filters.yml')
+        File.write(config_path, <<~YAML)
+          source: github
+          channels:
+            - public/standards
+          stages:
+            - published
+          file_routing: flat
+          github:
+            organizations:
+              - TestOrg
+        YAML
+
+        config = described_class.load(config_path)
+        expect(config.channels).to eq(['public/standards'])
+        expect(config.stages).to eq(['published'])
+        expect(config.file_routing).to eq('flat')
+      end
+    end
+  end
+end

--- a/spec/aggregation/aggregation_pipeline_spec.rb
+++ b/spec/aggregation/aggregation_pipeline_spec.rb
@@ -11,20 +11,20 @@ RSpec.describe Metanorma::Release::AggregationPipeline do
 
   let(:sample_metadata_json) do
     {
-      "version" => 1, "id" => "cc-18011", "title" => "Test Doc",
-      "edition" => "1", "stage" => "published", "doctype" => "standard",
-      "formats" => %w[html pdf], "channels" => ["public/standards"],
-      "flavor" => "cc", "sourcePath" => "sources/cc-18011.adoc"
+      'version' => 1, 'id' => 'cc-18011', 'title' => 'Test Doc',
+      'edition' => '1', 'stage' => 'published', 'doctype' => 'standard',
+      'formats' => %w[html pdf], 'channels' => ['public/standards'],
+      'flavor' => 'cc', 'sourcePath' => 'sources/cc-18011.adoc'
     }
   end
 
-  def build_release(tag: "cc-18011/ed1", stage: "published", channels: ["public/standards"])
-    meta = sample_metadata_json.merge("stage" => stage, "channels" => channels)
+  def build_release(tag: 'cc-18011/ed1', stage: 'published', channels: ['public/standards'])
+    meta = sample_metadata_json.merge('stage' => stage, 'channels' => channels)
     body = "content-hash:abc123\n<!-- mn-release-metadata\n#{JSON.generate(meta)}\n-->"
     mock_release_class.new(
       tag_name: tag, body: body, prerelease: false, draft: false,
-      html_url: "https://example.com/release", published_at: "2026-05-14T00:00:00Z",
-      assets: [mock_asset_class.new(name: "cc-18011-ed1.zip", browser_download_url: "https://example.com/asset.zip", size: 1024, data: "zip-data")]
+      html_url: 'https://example.com/release', published_at: '2026-05-14T00:00:00Z',
+      assets: [mock_asset_class.new(name: 'cc-18011-ed1.zip', browser_download_url: 'https://example.com/asset.zip', size: 1024, data: 'zip-data')]
     )
   end
 
@@ -40,7 +40,7 @@ RSpec.describe Metanorma::Release::AggregationPipeline do
       include Metanorma::Release::ReleaseFetcher
       def fetch(repo, etag: nil)
         releases = releases_by_repo[repo.to_s] || []
-        Metanorma::Release::FetchResult.new(releases: releases, etag: "etag-#{repo.to_s}", unchanged?: false)
+        Metanorma::Release::FetchResult.new(releases: releases, etag: "etag-#{repo}", unchanged?: false)
       end
     end.new(releases_by_repo)
   end
@@ -57,60 +57,165 @@ RSpec.describe Metanorma::Release::AggregationPipeline do
       include Metanorma::Release::Packager
       def process(_zip_data, metadata)
         Metanorma::Release::AssetProcessor::ProcessResult.new(
-          files: [Metanorma::Release::DocumentFile.new(name: "#{metadata['id']}.html", path: "#{metadata['id']}/#{metadata['id']}.html")],
-          channels: metadata["channels"]
+          files: [Metanorma::Release::DocumentFile.new(name: "#{metadata['id']}.html",
+                                                       path: "#{metadata['id']}/#{metadata['id']}.html")],
+          channels: metadata['channels']
         )
       end
     end.new([])
   end
 
-  describe "happy path" do
-    it "aggregates documents from repos" do
-      repos = [Metanorma::Release::RepoRef.new(owner: "CC", repo: "test-repo")]
-      releases = { "CC/test-repo" => [build_release] }
+  def build_deps(discoverer: mock_discoverer([]), fetcher: mock_fetcher({}),
+                 manifest_reader: mock_manifest_reader,
+                 channel_filter: Metanorma::Release::ChannelFilter.new([]),
+                 stage_filter: Metanorma::Release::StageFilter.new([]),
+                 asset_processor: mock_asset_processor,
+                 delta_state: Metanorma::Release::NullDeltaState.new)
+    described_class::Dependencies.new(
+      discoverer: discoverer, fetcher: fetcher,
+      manifest_reader: manifest_reader,
+      channel_filter: channel_filter, stage_filter: stage_filter,
+      asset_processor: asset_processor, delta_state: delta_state
+    )
+  end
 
-      deps = described_class::Dependencies.new(
-        discoverer: mock_discoverer(repos),
-        fetcher: mock_fetcher(releases),
-        manifest_reader: mock_manifest_reader,
-        channel_filter: Metanorma::Release::ChannelFilter.new([]),
-        stage_filter: Metanorma::Release::StageFilter.new([]),
-        asset_processor: mock_asset_processor,
-        delta_state: Metanorma::Release::NullDeltaState.new
-      )
+  def build_config(**overrides)
+    defaults = { organizations: [], channels: [], topic: 'test',
+                 concurrency: 1, include_drafts: false, fail_on_error: false }
+    described_class::Config.new(defaults.merge(overrides))
+  end
 
-      config = described_class::Config.new(
-        organizations: ["CC"], channels: [], topic: "test",
-        concurrency: 1, include_drafts: true, fail_on_error: false
-      )
+  describe 'happy path' do
+    it 'aggregates documents from repos' do
+      repos = [Metanorma::Release::RepoRef.new(owner: 'CC', repo: 'test-repo')]
+      releases = { 'CC/test-repo' => [build_release] }
 
-      result = described_class.new(deps).run(config, "/tmp/out")
+      result = described_class.new(build_deps(
+                                     discoverer: mock_discoverer(repos),
+                                     fetcher: mock_fetcher(releases)
+                                   )).run(build_config, '/tmp/out')
+
       expect(result.documents.length).to eq(1)
-      expect(result.documents.first.id).to eq("cc-18011")
+      expect(result.documents.first.id).to eq('cc-18011')
       expect(result.repo_count).to eq(1)
     end
   end
 
-  describe "empty input" do
-    it "returns empty result for no repos" do
-      deps = described_class::Dependencies.new(
-        discoverer: mock_discoverer([]),
-        fetcher: mock_fetcher({}),
-        manifest_reader: mock_manifest_reader,
-        channel_filter: Metanorma::Release::ChannelFilter.new([]),
-        stage_filter: Metanorma::Release::StageFilter.new([]),
-        asset_processor: mock_asset_processor,
-        delta_state: Metanorma::Release::NullDeltaState.new
-      )
-
-      config = described_class::Config.new(
-        organizations: [], channels: [], topic: "test",
-        concurrency: 1, include_drafts: false, fail_on_error: false
-      )
-
-      result = described_class.new(deps).run(config, "/tmp/out")
+  describe 'empty input' do
+    it 'returns empty result for no repos' do
+      result = described_class.new(build_deps).run(build_config, '/tmp/out')
       expect(result.documents).to be_empty
       expect(result.repo_count).to eq(0)
+    end
+  end
+
+  describe 'error handling' do
+    it 'collects failed repos when fail_on_error is false' do
+      repos = [Metanorma::Release::RepoRef.new(owner: 'CC', repo: 'test-repo')]
+      failing_fetcher = Struct.new(:repos) do
+        include Metanorma::Release::ReleaseFetcher
+        def fetch(_repo, etag: nil)
+          raise 'Network error'
+        end
+      end.new(repos)
+
+      result = described_class.new(build_deps(
+                                     discoverer: mock_discoverer(repos),
+                                     fetcher: failing_fetcher
+                                   )).run(build_config(fail_on_error: false), '/tmp/out')
+
+      expect(result.failed_repos.length).to eq(1)
+      expect(result.failed_repos.first.tag).to eq('CC/test-repo')
+    end
+
+    it 'raises on failure when fail_on_error is true' do
+      repos = [Metanorma::Release::RepoRef.new(owner: 'CC', repo: 'test-repo')]
+      failing_fetcher = Struct.new(:repos) do
+        include Metanorma::Release::ReleaseFetcher
+        def fetch(_repo, etag: nil)
+          raise 'Network error'
+        end
+      end.new(repos)
+
+      expect do
+        described_class.new(build_deps(
+                              discoverer: mock_discoverer(repos),
+                              fetcher: failing_fetcher
+                            )).run(build_config(fail_on_error: true), '/tmp/out')
+      end.to raise_error('Network error')
+    end
+  end
+
+  describe 'channel filtering' do
+    it 'excludes documents not matching channel filter' do
+      repos = [Metanorma::Release::RepoRef.new(owner: 'CC', repo: 'test-repo')]
+      releases = { 'CC/test-repo' => [build_release(channels: ['internal/secrets'])] }
+
+      filter = Metanorma::Release::ChannelFilter.new(['public/standards'])
+      result = described_class.new(build_deps(
+                                     discoverer: mock_discoverer(repos),
+                                     fetcher: mock_fetcher(releases),
+                                     channel_filter: filter
+                                   )).run(build_config, '/tmp/out')
+
+      expect(result.documents.length).to eq(0)
+    end
+  end
+
+  describe 'stage filtering' do
+    it 'excludes documents not matching stage filter' do
+      repos = [Metanorma::Release::RepoRef.new(owner: 'CC', repo: 'test-repo')]
+      releases = { 'CC/test-repo' => [build_release(stage: 'working-draft')] }
+
+      filter = Metanorma::Release::StageFilter.new(['published'])
+      result = described_class.new(build_deps(
+                                     discoverer: mock_discoverer(repos),
+                                     fetcher: mock_fetcher(releases),
+                                     stage_filter: filter
+                                   )).run(build_config, '/tmp/out')
+
+      expect(result.documents.length).to eq(0)
+    end
+  end
+
+  describe 'draft filtering' do
+    it 'excludes prerelease when include_drafts is false' do
+      repos = [Metanorma::Release::RepoRef.new(owner: 'CC', repo: 'test-repo')]
+      release = mock_release_class.new(
+        tag_name: 'cc-18011/ed1-wd', body: 'no metadata', prerelease: true,
+        draft: false, html_url: 'https://example.com', published_at: '2026-01-01',
+        assets: [mock_asset_class.new(name: 'test.zip', browser_download_url: 'https://example.com', size: 100, data: 'zip')]
+      )
+
+      releases = { 'CC/test-repo' => [release] }
+      result = described_class.new(build_deps(
+                                     discoverer: mock_discoverer(repos),
+                                     fetcher: mock_fetcher(releases)
+                                   )).run(build_config(include_drafts: false), '/tmp/out')
+
+      expect(result.documents.length).to eq(0)
+    end
+  end
+
+  describe 'manifest reader' do
+    it "skips repos whose manifest channels don't overlap with filter" do
+      repos = [Metanorma::Release::RepoRef.new(owner: 'CC', repo: 'test-repo')]
+      reader = Struct.new(:ch) do
+        include Metanorma::Release::ManifestReader
+        def read(_repo) = ch
+      end.new(['internal/secrets'])
+
+      filter = Metanorma::Release::ChannelFilter.new(['public/standards'])
+      releases = { 'CC/test-repo' => [build_release] }
+
+      result = described_class.new(build_deps(
+                                     discoverer: mock_discoverer(repos),
+                                     fetcher: mock_fetcher(releases),
+                                     manifest_reader: reader,
+                                     channel_filter: filter
+                                   )).run(build_config, '/tmp/out')
+
+      expect(result.documents.length).to eq(0)
     end
   end
 end

--- a/spec/domain/release_tag_spec.rb
+++ b/spec/domain/release_tag_spec.rb
@@ -1,78 +1,96 @@
 # frozen_string_literal: true
 
 RSpec.describe Metanorma::Release::ReleaseTag do
-  let(:doc_id) { Metanorma::Release::DocumentId.from_raw("CC 18011") }
+  let(:doc_id) { Metanorma::Release::DocumentId.from_raw('CC 18011') }
 
-  describe ".from" do
-    it "creates published tag cc-18011/ed1" do
-      version = Metanorma::Release::DocumentVersion.published(edition: "1")
+  describe '.from' do
+    it 'creates published tag cc-18011/ed1' do
+      version = Metanorma::Release::DocumentVersion.published(edition: '1')
       tag = described_class.from(doc_id, version)
-      expect(tag.to_s).to eq("cc-18011/ed1")
+      expect(tag.to_s).to eq('cc-18011/ed1')
       expect(tag).not_to be_pre_release
     end
 
-    it "creates draft tag cc-18011/ed1-wd" do
-      stage = Metanorma::Release::DocumentStage.from_status("working-draft")
-      version = Metanorma::Release::DocumentVersion.from("1", stage)
+    it 'creates draft tag cc-18011/ed1-wd' do
+      stage = Metanorma::Release::DocumentStage.from_status('working-draft')
+      version = Metanorma::Release::DocumentVersion.from('1', stage)
       tag = described_class.from(doc_id, version)
-      expect(tag.to_s).to eq("cc-18011/ed1-wd")
+      expect(tag.to_s).to eq('cc-18011/ed1-wd')
       expect(tag).to be_pre_release
     end
   end
 
-  describe ".create" do
-    it "creates tag with explicit pre_release flag" do
-      tag = described_class.create("cc-18011/ed1", pre_release: false)
-      expect(tag.to_s).to eq("cc-18011/ed1")
+  describe '.create' do
+    it 'creates tag with explicit pre_release flag' do
+      tag = described_class.create('cc-18011/ed1', pre_release: false)
+      expect(tag.to_s).to eq('cc-18011/ed1')
     end
 
-    it "raises without slash" do
-      expect { described_class.create("cc-18011", pre_release: false) }
+    it 'raises without slash' do
+      expect { described_class.create('cc-18011', pre_release: false) }
         .to raise_error(ArgumentError, /slash/)
     end
   end
 
-  describe ".parse" do
-    it "extracts tag from cc-18011/ed1" do
-      tag = described_class.parse("cc-18011/ed1")
-      expect(tag.to_s).to eq("cc-18011/ed1")
+  describe '.parse' do
+    it 'extracts tag from cc-18011/ed1' do
+      tag = described_class.parse('cc-18011/ed1')
+      expect(tag.to_s).to eq('cc-18011/ed1')
       expect(tag).not_to be_pre_release
     end
 
-    it "detects pre-release from version suffix" do
-      tag = described_class.parse("cc-18011/ed1-wd")
+    it 'detects pre-release from version suffix' do
+      tag = described_class.parse('cc-18011/ed1-wd')
       expect(tag).to be_pre_release
     end
 
-    it "detects pre-release for committee-draft" do
-      tag = described_class.parse("cc-18011/ed1-cd")
+    it 'detects pre-release for committee-draft' do
+      tag = described_class.parse('cc-18011/ed1-cd')
       expect(tag).to be_pre_release
     end
 
-    it "raises on missing slash" do
-      expect { described_class.parse("cc-18011") }.to raise_error(ArgumentError, /slash/)
+    it 'raises on missing slash' do
+      expect { described_class.parse('cc-18011') }.to raise_error(ArgumentError, /slash/)
     end
   end
 
-  describe "round-trip" do
-    it "to_s roundtrips through parse" do
-      version = Metanorma::Release::DocumentVersion.published(edition: "1")
+  describe 'round-trip' do
+    it 'to_s roundtrips through parse' do
+      version = Metanorma::Release::DocumentVersion.published(edition: '1')
       tag = described_class.from(doc_id, version)
       expect(described_class.parse(tag.to_s).to_s).to eq(tag.to_s)
     end
   end
 
-  describe "equality" do
-    it "same tag string is equal" do
-      a = described_class.create("cc-18011/ed1", pre_release: false)
-      b = described_class.create("cc-18011/ed1", pre_release: false)
+  describe 'equality' do
+    it 'same tag string is equal' do
+      a = described_class.create('cc-18011/ed1', pre_release: false)
+      b = described_class.create('cc-18011/ed1', pre_release: false)
       expect(a).to eql(b)
     end
 
-    it "different tag is not equal" do
-      a = described_class.create("cc-18011/ed1", pre_release: false)
-      b = described_class.create("cc-18011/ed2", pre_release: false)
+    it 'different tag is not equal' do
+      a = described_class.create('cc-18011/ed1', pre_release: false)
+      b = described_class.create('cc-18011/ed2', pre_release: false)
       expect(a).not_to eql(b)
+    end
+
+    it 'same tag string but different pre_release is not equal' do
+      a = described_class.create('cc-18011/ed1', pre_release: false)
+      b = described_class.create('cc-18011/ed1', pre_release: true)
+      expect(a).not_to eql(b)
+    end
+
+    it 'same tag and pre_release have same hash' do
+      a = described_class.create('cc-18011/ed1', pre_release: false)
+      b = described_class.create('cc-18011/ed1', pre_release: false)
+      expect(a.hash).to eq(b.hash)
+    end
+
+    it 'different pre_release produces different hash' do
+      a = described_class.create('cc-18011/ed1', pre_release: false)
+      b = described_class.create('cc-18011/ed1', pre_release: true)
+      expect(a.hash).not_to eq(b.hash)
     end
   end
 end

--- a/spec/release/document_metadata_spec.rb
+++ b/spec/release/document_metadata_spec.rb
@@ -1,37 +1,88 @@
 # frozen_string_literal: true
 
 RSpec.describe Metanorma::Release::DocumentMetadata do
+  let(:version) do
+    Metanorma::Release::DocumentVersion.from('1', Metanorma::Release::DocumentStage.published)
+  end
+
   let(:metadata) do
     described_class.new(
-      id: Metanorma::Release::DocumentId.from_raw("CC 18011"),
-      title: "Test Doc",
-      version: Metanorma::Release::DocumentVersion.from("1", Metanorma::Release::DocumentStage.published),
-      doctype: "standard",
-      document_type: "standard",
-      flavor: "cc",
-      revdate: "2025-06-01",
-      source_path: "sources/cc-18011.adoc",
-      output_dir: "/tmp/test",
+      id: Metanorma::Release::DocumentId.from_raw('CC 18011'),
+      title: 'Test Doc',
+      version: version,
+      doctype: 'standard',
+      document_type: 'standard',
+      flavor: 'cc',
+      revdate: '2025-06-01',
+      source_path: 'sources/cc-18011.adoc',
+      output_dir: '/tmp/test',
       formats: %w[html pdf],
-      file_base_name: "cc-18011"
+      file_base_name: 'cc-18011'
     )
   end
 
-  it "is frozen" do
+  it 'is frozen' do
     expect(metadata).to be_frozen
   end
 
-  describe "#[]" do
-    it "returns source_path" do
-      expect(metadata["source_path"]).to eq("sources/cc-18011.adoc")
+  describe 'attribute readers' do
+    it 'exposes id as DocumentId' do
+      expect(metadata.id).to be_a(Metanorma::Release::DocumentId)
+      expect(metadata.id.to_s).to eq('cc-18011')
     end
 
-    it "returns id as a DocumentId" do
-      expect(metadata["id"].to_s).to eq("cc-18011")
+    it 'exposes title' do
+      expect(metadata.title).to eq('Test Doc')
     end
 
-    it "returns nil for unknown key" do
-      expect(metadata["nonexistent"]).to be_nil
+    it 'exposes version' do
+      expect(metadata.version).to eq(version)
     end
+
+    it 'exposes doctype' do
+      expect(metadata.doctype).to eq('standard')
+    end
+
+    it 'exposes document_type' do
+      expect(metadata.document_type).to eq('standard')
+    end
+
+    it 'exposes flavor' do
+      expect(metadata.flavor).to eq('cc')
+    end
+
+    it 'exposes revdate' do
+      expect(metadata.revdate).to eq('2025-06-01')
+    end
+
+    it 'exposes output_dir' do
+      expect(metadata.output_dir).to eq('/tmp/test')
+    end
+
+    it 'exposes formats' do
+      expect(metadata.formats).to eq(%w[html pdf])
+    end
+
+    it 'exposes file_base_name' do
+      expect(metadata.file_base_name).to eq('cc-18011')
+    end
+  end
+
+  describe '#[]' do
+    it 'returns source_path' do
+      expect(metadata['source_path']).to eq('sources/cc-18011.adoc')
+    end
+
+    it 'returns id as a DocumentId' do
+      expect(metadata['id'].to_s).to eq('cc-18011')
+    end
+
+    it 'returns nil for unknown key' do
+      expect(metadata['nonexistent']).to be_nil
+    end
+  end
+
+  it 'freezes formats array' do
+    expect(metadata.formats).to be_frozen
   end
 end

--- a/spec/release/zip_packager_spec.rb
+++ b/spec/release/zip_packager_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'zip'
+
+RSpec.describe Metanorma::Release::ZipPackager do
+  let(:packager) { described_class.new }
+
+  def create_test_files(dir, files)
+    files.each do |name, content|
+      File.write(File.join(dir, name), content)
+    end
+  end
+
+  def build_metadata(output_dir:, id: 'cc-18011', formats: %w[html pdf])
+    Metanorma::Release::DocumentMetadata.new(
+      id: Metanorma::Release::DocumentId.from_raw(id),
+      title: 'Test', version: Metanorma::Release::DocumentVersion.published(edition: '1'),
+      doctype: 'standard', document_type: 'standard',
+      flavor: 'cc', revdate: '2024-01-01',
+      source_path: "sources/#{id}.adoc", output_dir: output_dir,
+      formats: formats, file_base_name: id
+    )
+  end
+
+  describe '#package' do
+    it 'creates a zip with matching files' do
+      Dir.mktmpdir do |dir|
+        create_test_files(dir, { 'cc-18011.html' => '<html/>', 'cc-18011.pdf' => 'PDF' })
+        metadata = build_metadata(output_dir: dir)
+
+        artifact = packager.package(metadata, canonical_base: 'cc-18011-ed1')
+
+        expect(artifact.zip_path).to end_with('cc-18011-ed1.zip')
+        expect(artifact.asset_name).to eq('cc-18011-ed1.zip')
+        expect(artifact.size).to be > 0
+        expect(File.exist?(artifact.zip_path)).to be true
+
+        entries = Zip::File.open(artifact.zip_path) { |z| z.map(&:name) }
+        expect(entries).to include('cc-18011-ed1.html', 'cc-18011-ed1.pdf')
+      end
+    end
+
+    it 'includes only files matching the base name' do
+      Dir.mktmpdir do |dir|
+        create_test_files(dir, {
+                            'cc-18011.html' => '<html/>',
+                            'other-doc.pdf' => 'PDF'
+                          })
+        metadata = build_metadata(output_dir: dir)
+
+        artifact = packager.package(metadata, canonical_base: 'cc-18011-ed1')
+
+        entries = Zip::File.open(artifact.zip_path) { |z| z.map(&:name) }
+        expect(entries).to include('cc-18011-ed1.html')
+        expect(entries).not_to include('cc-18011-ed1.pdf')
+      end
+    end
+
+    it 'replaces existing zip' do
+      Dir.mktmpdir do |dir|
+        create_test_files(dir, { 'cc-18011.html' => 'v1' })
+        metadata = build_metadata(output_dir: dir)
+        packager.package(metadata, canonical_base: 'cc-18011-ed1')
+
+        create_test_files(dir, { 'cc-18011.html' => 'v2-longer-content' })
+        artifact = packager.package(metadata, canonical_base: 'cc-18011-ed1')
+
+        content = Zip::File.open(artifact.zip_path) { |z| z.read('cc-18011-ed1.html') }
+        expect(content).to eq('v2-longer-content')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Code quality improvements across the codebase:

- **Unify release/asset data types** across platform adapters for consistency
- **Fix `ReleaseTag` eql?/hash** to include `pre_release` flag
- **Use `private_class_method`** and eliminate double YAML parsing
- **Add command classes** (`aggregate`, `package`, `publish`) with aggregate config and CLI executable
- **Expand spec coverage** for aggregation pipeline, metadata, and packager

## Changes

- Refactored platform adapters to share unified data types
- Added `Commands::Aggregate`, `Commands::Package`, `Commands::Publish` with `AggregateConfig` and `ConfigResolver`
- Added `exe/metanorma-release` CLI entry point
- Expanded test coverage for edge cases in aggregation pipeline, document metadata, and zip packager
- Fixed value object equality bugs in `ReleaseTag`
- Documentation updates (README, CHANGELOG, CLAUDE.md)

## Test plan

- [x] `bundle exec rspec` passes all tests
- [x] No new runtime dependencies introduced
- [x] Value object equality semantics verified with expanded specs