### PR TITLE
fix: require metanorma/release before cli to register autoloads

### DIFF
--- a/exe/metanorma-release
+++ b/exe/metanorma-release
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "metanorma/release"
 require "metanorma/release/cli"
 
 Metanorma::Release::CLI.start(ARGV)


### PR DESCRIPTION
Fixes NameError when running from an installed gem. The autoload declarations in `lib/metanorma/release.rb` were never registered because `exe/metanorma-release` only required the CLI file.