### PR TITLE
feat: config-driven aggregate command with GITHUB_TOKEN fallback

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -133,6 +133,8 @@ metanorma-release release [options]
 === `metanorma-release aggregate`
 
 Aggregate published releases from multiple repositories into a unified file tree.
+Reads config from `metanorma.aggregate.yml` if present (auto-detected).
+Idempotent: uses cached delta state (`.cache/aggregate/`) to skip unchanged repos.
 
 [source,sh]
 ----
@@ -142,20 +144,39 @@ metanorma-release aggregate [options]
 [cols="1m,3",options="header"]
 |===
 |Option |Description
+|`--config FILE` |Config file (default: `metanorma.aggregate.yml`)
 |`--source SOURCE` |Discovery source: `github`, `local:PATH` (default: `github`)
-|`--organizations ORGS` |Organization list
+|`--organizations ORGS` |Organization list (overrides config)
 |`--topic TOPIC` |Repository topic filter (default: `metanorma-release`)
 |`--repos REPOS` |Explicit repo list
 |`--channels CHANS` |Filter channels
 |`--stages STAGES` |Filter stages
 |`--output-dir DIR` |Output directory (default: `_site/cc`)
 |`--file-routing MODE` |File layout: `by-document`, `flat`, `by-format` (default: `by-document`)
-|`--cache-dir DIR` |Cache directory for delta state
 |`--[no-]include-drafts` |Include draft releases
 |`--concurrency N` |Parallel repos (default: 4)
 |`--min-documents N` |Fail if fewer documents found (default: 0)
-|`--token TOKEN` |Platform auth token
+|`--token TOKEN` |Platform auth token (falls back to `GITHUB_TOKEN` env)
 |===
+
+==== Aggregate config file
+
+Create `metanorma.aggregate.yml` in your project root:
+
+[source,yaml]
+----
+source: github
+output_dir: _site/cc
+file_routing: flat
+cache_dir: .cache/aggregate
+
+github:
+  organizations:
+    - MyOrg
+  topic: metanorma-release
+----
+
+CLI flags override config file values. Cache is always enabled (defaults to `.cache/aggregate/`).
 
 == Concepts
 

--- a/lib/metanorma/release/cli.rb
+++ b/lib/metanorma/release/cli.rb
@@ -88,9 +88,10 @@ module Metanorma
       option :min_documents, type: :numeric, default: 0,
                              desc: "Minimum required documents"
       option :token, type: :string, desc: "Platform auth token"
+      option :config, type: :string, desc: "Config file (default: metanorma.aggregate.yml)"
 
       def aggregate
-        config = AggregateCommand::Config.new(
+        config = AggregateCommand.build_config(
           source: options[:source],
           organizations: options[:organizations],
           topic: options[:topic],
@@ -105,13 +106,14 @@ module Metanorma
           min_documents: options[:min_documents],
           token: options[:token],
           create_zip: nil,
+          config: options[:config],
         )
         result = AggregateCommand.new(config).call
         print_aggregate_result(result)
 
-        if options[:min_documents].positive? && result.publications.length < options[:min_documents]
+        if config.min_documents.positive? && result.publications.length < config.min_documents
           raise PipelineError,
-                "Found #{result.publications.length} documents, minimum is #{options[:min_documents]}"
+                "Found #{result.publications.length} documents, minimum is #{config.min_documents}"
         end
 
         unless result.failed_repos.empty?

--- a/lib/metanorma/release/commands/aggregate.rb
+++ b/lib/metanorma/release/commands/aggregate.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "yaml"
+
 module Metanorma
   module Release
     class AggregateCommand
@@ -9,6 +11,9 @@ module Metanorma
         :include_drafts, :concurrency, :min_documents, :token, :create_zip,
         keyword_init: true
       )
+
+      DEFAULT_CONFIG_FILE = "metanorma.aggregate.yml"
+      DEFAULT_CACHE_DIR = ".cache/aggregate"
 
       def initialize(config)
         @config = config
@@ -26,6 +31,54 @@ module Metanorma
 
         stamp_primary_identifiers(index)
         result
+      end
+
+      def self.build_config(cli_options)
+        file_data = load_config_file(cli_options[:config])
+        merged = merge_config(file_data, cli_options)
+        Config.new(
+          source: merged[:source],
+          organizations: merged[:organizations],
+          topic: merged[:topic],
+          repos: merged[:repos],
+          channels: merged[:channels],
+          stages: merged[:stages],
+          output_dir: merged[:output_dir],
+          file_routing: merged[:file_routing],
+          cache_dir: merged[:cache_dir] || DEFAULT_CACHE_DIR,
+          include_drafts: merged[:include_drafts],
+          concurrency: merged[:concurrency],
+          min_documents: merged[:min_documents],
+          token: merged[:token],
+          create_zip: merged[:create_zip],
+        )
+      end
+
+      def self.load_config_file(path)
+        path ||= DEFAULT_CONFIG_FILE
+        return {} unless File.exist?(path)
+
+        YAML.safe_load_file(path, permitted_classes: [Symbol]) || {}
+      end
+
+      def self.merge_config(file_data, cli_options)
+        gh = file_data["github"] || {}
+        {
+          source: cli_options[:source] || file_data["source"],
+          organizations: cli_options[:organizations].any? ? cli_options[:organizations] : Array(gh["organizations"]),
+          topic: cli_options[:topic] || gh["topic"],
+          repos: cli_options[:repos] || file_data["repos"],
+          channels: cli_options[:channels].any? ? cli_options[:channels] : Array(file_data["channels"]),
+          stages: cli_options[:stages].any? ? cli_options[:stages] : Array(file_data["stages"]),
+          output_dir: cli_options[:output_dir] || file_data["output_dir"],
+          file_routing: cli_options[:file_routing] || file_data["file_routing"],
+          cache_dir: cli_options[:cache_dir] || file_data["cache_dir"],
+          include_drafts: cli_options[:include_drafts] || file_data["include_drafts"],
+          concurrency: cli_options[:concurrency] || file_data["concurrency"],
+          min_documents: cli_options[:min_documents] || file_data["min_documents"],
+          token: cli_options[:token],
+          create_zip: cli_options[:create_zip],
+        }
       end
 
       private

--- a/lib/metanorma/release/platform_factory.rb
+++ b/lib/metanorma/release/platform_factory.rb
@@ -64,7 +64,8 @@ module Metanorma
 
       def self.build_github_client(token)
         require "octokit"
-        token ? Octokit::Client.new(access_token: token) : Octokit::Client.new
+        access_token = token || ENV.fetch("GITHUB_TOKEN", nil)
+        access_token ? Octokit::Client.new(access_token: access_token) : Octokit::Client.new
       end
 
       def self.register_publisher(name, factory)


### PR DESCRIPTION
## Changes

- **Config file support**: `aggregate` command auto-detects `metanorma.aggregate.yml`. All settings (orgs, topic, file routing, output dir, cache dir) come from config. CLI flags override.
- **GITHUB_TOKEN env fallback**: `PlatformFactory.build_github_client` falls back to `ENV['GITHUB_TOKEN']` when no `--token` flag is passed.
- **Cache by default**: Cache dir defaults to `.cache/aggregate/` for idempotent aggregate runs.
- **README**: Documents config file structure and usage.

## Config file format

```yaml
source: github
output_dir: _site/cc
file_routing: flat
cache_dir: .cache/aggregate

github:
  organizations:
    - CalConnect
  topic: metanorma-release
```

## Result

Consumer projects now need only:

```ruby
# Rakefile
task :fetch do
  sh 'bundle exec metanorma-release aggregate'
end
```

No CLI flag salad. Config-driven. Idempotent.