### PR TITLE
feat: aggregate produces Jekyll data file via data_dir config

### DIFF
--- a/lib/metanorma/release/cli.rb
+++ b/lib/metanorma/release/cli.rb
@@ -82,6 +82,7 @@ module Metanorma
       option :file_routing, type: :string, default: "by-document",
                             desc: "File routing (by-document|flat|by-format)"
       option :cache_dir, type: :string, desc: "Cache directory"
+      option :data_dir, type: :string, desc: "Write flattened documents.json for site generators"
       option :include_drafts, type: :boolean, default: false,
                               desc: "Include draft releases"
       option :concurrency, type: :numeric, default: 4
@@ -101,6 +102,7 @@ module Metanorma
           output_dir: options[:output_dir],
           file_routing: options[:file_routing],
           cache_dir: options[:cache_dir],
+          data_dir: options[:data_dir],
           include_drafts: options[:include_drafts],
           concurrency: options[:concurrency],
           min_documents: options[:min_documents],

--- a/lib/metanorma/release/commands/aggregate.rb
+++ b/lib/metanorma/release/commands/aggregate.rb
@@ -8,7 +8,8 @@ module Metanorma
       Config = Struct.new(
         :source, :organizations, :topic, :repos, :repo_pattern, :local_path,
         :channels, :stages, :output_dir, :file_routing, :cache_dir,
-        :include_drafts, :concurrency, :min_documents, :token, :create_zip,
+        :data_dir, :include_drafts, :concurrency, :min_documents, :token,
+        :create_zip,
         keyword_init: true
       )
 
@@ -24,7 +25,8 @@ module Metanorma
         return result unless result.publications.any?
 
         index = build_index(result)
-        site = Site.new(index: index, output_dir: @config.output_dir)
+        site = Site.new(index: index, output_dir: @config.output_dir,
+                        data_dir: @config.data_dir)
         site.write!
         site.enrich!
         site.package! if @config.create_zip
@@ -46,6 +48,7 @@ module Metanorma
           output_dir: merged[:output_dir],
           file_routing: merged[:file_routing],
           cache_dir: merged[:cache_dir] || DEFAULT_CACHE_DIR,
+          data_dir: merged[:data_dir],
           include_drafts: merged[:include_drafts],
           concurrency: merged[:concurrency],
           min_documents: merged[:min_documents],
@@ -73,6 +76,7 @@ module Metanorma
           output_dir: cli_options[:output_dir] || file_data["output_dir"],
           file_routing: cli_options[:file_routing] || file_data["file_routing"],
           cache_dir: cli_options[:cache_dir] || file_data["cache_dir"],
+          data_dir: cli_options[:data_dir] || file_data["data_dir"],
           include_drafts: cli_options[:include_drafts] || file_data["include_drafts"],
           concurrency: cli_options[:concurrency] || file_data["concurrency"],
           min_documents: cli_options[:min_documents] || file_data["min_documents"],

--- a/lib/metanorma/release/site.rb
+++ b/lib/metanorma/release/site.rb
@@ -9,9 +9,10 @@ module Metanorma
     class Site
       attr_reader :index, :output_dir
 
-      def initialize(index:, output_dir:)
+      def initialize(index:, output_dir:, data_dir: nil)
         @index = index
         @output_dir = output_dir
+        @data_dir = data_dir
       end
 
       def write!
@@ -22,29 +23,9 @@ module Metanorma
       def enrich!
         return if index.empty?
 
-        documents = index.publications.map do |pub|
-          rxl_file = pub.files.find { |f| f.format == "rxl" }
-          next pub.to_h unless rxl_file
-
-          rxl_path = File.join(output_dir, rxl_file.path)
-          next pub.to_h unless File.exist?(rxl_path)
-
-          bib = Relaton::Bib::Item.from_xml(File.read(rxl_path))
-          enriched = pub.to_h
-          enriched["bibliographic"] = bib.to_h
-          enriched
-        rescue StandardError => e
-          warn "  Skip #{pub.identifier}: #{e.message}"
-          pub.to_h
-        end
-
-        dest = File.join(output_dir, "relaton")
-        FileUtils.mkdir_p(dest)
-        index_data = { "root" => { "title" => "Document Registry",
-                                   "items" => documents.compact } }
-        File.write(File.join(dest, "index.json"),
-                   JSON.pretty_generate(index_data))
-        File.write(File.join(dest, "index.yaml"), YAML.dump(index_data))
+        documents = enrich_documents
+        write_relaton_index(documents)
+        write_data_file(documents) if @data_dir
       end
 
       def package!(zip_path: nil)
@@ -60,6 +41,93 @@ module Metanorma
           end
         end
         path
+      end
+
+      private
+
+      def enrich_documents
+        index.publications.map do |pub|
+          enrich_publication(pub)
+        rescue StandardError => e
+          warn "  Skip #{pub.identifier}: #{e.message}"
+          pub.to_h
+        end
+      end
+
+      def enrich_publication(pub)
+        rxl_file = pub.files.find { |f| f.format == "rxl" }
+        return pub.to_h unless rxl_file
+
+        rxl_path = File.join(output_dir, rxl_file.path)
+        return pub.to_h unless File.exist?(rxl_path)
+
+        bib = Relaton::Bib::Item.from_xml(File.read(rxl_path))
+        pub.to_h.merge("bibliographic" => bib.to_h)
+      end
+
+      def write_relaton_index(documents)
+        dest = File.join(output_dir, "relaton")
+        FileUtils.mkdir_p(dest)
+        index_data = { "root" => { "title" => "Document Registry",
+                                   "items" => documents.compact } }
+        File.write(File.join(dest, "index.json"),
+                   JSON.pretty_generate(index_data))
+        File.write(File.join(dest, "index.yaml"), YAML.dump(index_data))
+      end
+
+      def write_data_file(documents)
+        FileUtils.mkdir_p(@data_dir)
+        items = documents.compact.map { |doc| flatten_for_site(doc) }
+        File.write(File.join(@data_dir, "documents.json"),
+                   JSON.pretty_generate({ "items" => items }))
+      end
+
+      def flatten_for_site(doc)
+        bib = doc["bibliographic"] || {}
+        doc_id = resolve_doc_id(bib, doc)
+        {
+          "slug" => doc["id"],
+          "id" => doc_id,
+          "title" => doc["title"].to_s,
+          "abstract" => extract_abstract(bib),
+          "stage" => (doc["stage"] || "published").to_s.downcase,
+          "doctype" => extract_doctype(bib) || doc.fetch("doctype", ""),
+          "edition" => doc["edition"],
+          "date" => extract_date(doc),
+          "channels" => doc["channels"] || [],
+          "formats" => doc["formats"] || [],
+          "files" => doc["files"] || [],
+        }
+      end
+
+      def resolve_doc_id(bib, doc)
+        extract_primary_id(bib) || doc["identifier"] || doc["id"]
+      end
+
+      def extract_primary_id(bib)
+        ids = bib["docidentifier"]
+        return nil unless ids&.any?
+
+        primary = ids.find { |di| di["primary"] == true } || ids.first
+        primary["content"]
+      end
+
+      def extract_doctype(bib)
+        bib.dig("ext", "doctype", "content")
+      end
+
+      def extract_abstract(bib)
+        abstracts = bib["abstract"]
+        return nil unless abstracts&.any?
+
+        abstracts.first["content"]
+      end
+
+      def extract_date(doc)
+        release_date = doc.dig("source", "releaseDate")
+        return nil unless release_date
+
+        release_date.to_s.split(/[T ]/).first
       end
     end
   end


### PR DESCRIPTION
When `data_dir` is set in `metanorma.aggregate.yml` (or via `--data-dir`), the aggregate command writes a flattened `documents.json` to that directory. Extracts doctype, abstract, date, and primary identifier from Relaton enrichment.

```yaml
# metanorma.aggregate.yml
data_dir: _data
```

Produces `_data/documents.json` with `{ items: [...] }` for Jekyll consumption.