### PR TITLE
fix: re-extract ZIP assets when delta-cached files missing from disk

### DIFF
--- a/lib/metanorma/release/aggregation_pipeline.rb
+++ b/lib/metanorma/release/aggregation_pipeline.rb
@@ -84,7 +84,7 @@ module Metanorma
 
       private
 
-      def process_repo(repo, _output_dir, config)
+      def process_repo(repo, output_dir, config)
         repo_key = repo.to_s
 
         manifest_channels = @deps.manifest_reader.read(repo)
@@ -120,9 +120,11 @@ module Metanorma
 
           if @deps.delta_state.processed?(repo_key, tag, content_hash)
             files = @deps.delta_state.release_files(repo_key, tag)
-            publications << build_publication(metadata, files, content_hash,
-                                              release, repo)
-            next
+            if files.all? { |f| File.exist?(File.join(output_dir, f)) }
+              publications << build_publication(metadata, files, content_hash,
+                                                release, repo)
+              next
+            end
           end
 
           zip_asset = find_zip_asset(release)

--- a/lib/metanorma/release/version.rb
+++ b/lib/metanorma/release/version.rb
@@ -2,6 +2,6 @@
 
 module Metanorma
   module Release
-    VERSION = "0.2.22"
+    VERSION = "0.2.23"
   end
 end


### PR DESCRIPTION
## Problem
When the CI caches the delta state () but NOT the output directory (), the delta cache says releases are "already processed" and skips downloading. But the extracted files (HTML, PDF, RXL) are not on disk. The enrichment step () then can't find RXL files, falls back to un-enriched data, and doctype/display_category are empty.

This caused standards.calconnect.org to show document counts on the index page but "No documents" on all category pages —  was empty because the doctype was empty because Relaton enrichment was skipped.

## Fix
In , verify that delta-cached files actually exist on disk before trusting the cache. If any file is missing, fall through to re-extract from the ZIP asset.