### PR TITLE
fix: add actual file paths to flattened documents

### DIFF
--- a/lib/metanorma/release/site.rb
+++ b/lib/metanorma/release/site.rb
@@ -112,6 +112,16 @@ module Metanorma
         hash["has_pdf"] = formats.include?("pdf")
         hash["has_xml"] = formats.include?("xml")
         hash["has_rxl"] = formats.include?("rxl")
+
+        files = hash["files"]
+        html_file = files.find { |f| f["format"] == "html" }
+        hash["html_path"] = html_file["path"] if html_file
+        pdf_file = files.find { |f| f["format"] == "pdf" }
+        hash["pdf_path"] = pdf_file["path"] if pdf_file
+        xml_file = files.find { |f| f["format"] == "xml" }
+        hash["xml_path"] = xml_file["path"] if xml_file
+        rxl_file = files.find { |f| f["format"] == "rxl" }
+        hash["rxl_path"] = rxl_file["path"] if rxl_file
       end
 
       def add_display_category(hash, doctype)

--- a/lib/metanorma/release/version.rb
+++ b/lib/metanorma/release/version.rb
@@ -2,6 +2,6 @@
 
 module Metanorma
   module Release
-    VERSION = "0.2.23"
+    VERSION = "0.2.24"
   end
 end


### PR DESCRIPTION
Templates were constructing links from doc.slug but filenames may include stage suffixes (-wd, -cd) that differ from the slug. Adds html_path, pdf_path, xml_path, rxl_path fields from actual file entries.